### PR TITLE
Add VERSION_VAR to find_package_handle_standard_args to handle FFTW version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           cmake -S test -B build \
             -DFFTW_ROOT="$HOME/fftw_install" \
-            -DFFTW_TEST_COMPONENTS="${fftw_components}"
+            -DFFTW_TEST_COMPONENTS="${fftw_components}" \
             -DFFTW_TEST_VERSION=3
 
   test-conda:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,24 @@ jobs:
           cmake -S test -B build \
             -DFFTW_TEST_COMPONENTS="${fftw_components}"
 
+      - name: Configure test with version 3
+        run: |
+          cmake -S test -B build \
+            -DFFTW_TEST_COMPONENTS="${fftw_components}" \
+            -DFFTW_TEST_VERSION=3
+
+      - name: Configure test with invalid version
+        run: |
+          set +e
+          cmake -S test -B build_version_fail -DFFTW_TEST_VERSION=999.99.9 2>/dev/null
+          STATUS=$?
+          if [ $STATUS -ne 0 ]; then
+            echo "PASS: find_package correctly rejected version 999.99.9"
+          else
+            echo "FAIL: find_package should have rejected version 999.99.9 but succeeded"
+            exit 1
+          fi
+
   test-source:
     name: Test source install
     runs-on: ubuntu-latest
@@ -79,6 +97,13 @@ jobs:
             -DFFTW_ROOT="$HOME/fftw_install" \
             -DFFTW_TEST_COMPONENTS="${fftw_components}"
 
+      - name: Configure test with version 3
+        run: |
+          cmake -S test -B build \
+            -DFFTW_ROOT="$HOME/fftw_install" \
+            -DFFTW_TEST_COMPONENTS="${fftw_components}"
+            -DFFTW_TEST_VERSION=3
+
   test-conda:
     name: Test conda-forge install
     runs-on: ubuntu-latest
@@ -99,3 +124,11 @@ jobs:
           cmake -S test -B build \
             -DFFTW_ROOT="$CONDA_PREFIX" \
             -DFFTW_TEST_COMPONENTS="${fftw_components}"
+
+      - name: Configure test with version 3
+        shell: micromamba-shell {0}
+        run: |
+          cmake -S test -B build \
+            -DFFTW_ROOT="$CONDA_PREFIX" \
+            -DFFTW_TEST_COMPONENTS="${fftw_components}" \
+            -DFFTW_TEST_VERSION=3

--- a/FindFFTW.cmake
+++ b/FindFFTW.cmake
@@ -7,7 +7,7 @@
 #   Copyright (c) 2017, Patrick Bos
 #
 # Usage:
-#   find_package(FFTW [REQUIRED] [QUIET] [COMPONENTS component1 ... componentX] )
+#   find_package(FFTW [<version>] [REQUIRED] [QUIET] [COMPONENTS component1 ... componentX] )
 #
 # It sets the following variables:
 #   FFTW_FOUND                  ... true if fftw is found on the system

--- a/FindFFTW.cmake
+++ b/FindFFTW.cmake
@@ -15,6 +15,7 @@
 #   FFTW_LIBRARIES              ... full paths to all found fftw libraries
 #   FFTW_[component]_LIB        ... full path to one of the components (see below)
 #   FFTW_INCLUDE_DIRS           ... fftw include directory paths
+#   FFTW_VERSION                ... version of the found fftw library
 #
 # The following variables will be checked by the function
 #   FFTW_USE_STATIC_LIBS        ... if true, only static libraries are found, otherwise both static and shared.
@@ -48,6 +49,9 @@ find_package(PkgConfig)
 if( PKG_CONFIG_FOUND AND NOT FFTW_ROOT )
     pkg_check_modules( PKG_FFTW QUIET "fftw3" )
 endif()
+
+# Set variables based on pkg-config results
+set(FFTW_VERSION ${PKG_FFTW_VERSION})
 
 #Check whether to search static or dynamic libs
 set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
@@ -398,7 +402,7 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(FFTW
     REQUIRED_VARS FFTW_INCLUDE_DIRS
-    VERSION_VAR PKG_FFTW_VERSION
+    VERSION_VAR FFTW_VERSION
     HANDLE_COMPONENTS
     )
 

--- a/FindFFTW.cmake
+++ b/FindFFTW.cmake
@@ -398,6 +398,7 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(FFTW
     REQUIRED_VARS FFTW_INCLUDE_DIRS
+    VERSION_VAR PKG_FFTW_VERSION
     HANDLE_COMPONENTS
     )
 

--- a/FindFFTW.cmake
+++ b/FindFFTW.cmake
@@ -45,13 +45,32 @@ endif()
 # Check if we can use PkgConfig
 find_package(PkgConfig)
 
-#Determine from PKG
+# Determine from PKG
 if( PKG_CONFIG_FOUND AND NOT FFTW_ROOT )
     pkg_check_modules( PKG_FFTW QUIET "fftw3" )
+    set( FFTW_VERSION ${PKG_FFTW_VERSION} )
+else()
+    # If pkg-config was skipped, there seems no way to get the version directly.
+    # Try to deduce the version from fftw-wisdom-to-conf instead.
+    #   (From @kprussing. See https://github.com/egpbos/findFFTW/pull/8)
+    execute_process(COMMAND ${FFTW_ROOT}/bin/fftw-wisdom-to-conf -V
+                    RESULT_VARIABLE _fftw_wtc_success
+                    OUTPUT_VARIABLE _fftw_wtc_stdout
+                    ERROR_VARIABLE _fftw_wtc_stderr)
+    if (_fftw_wtc_success EQUAL 0)
+        string(REGEX MATCH "FFTW *version *([0-9]+([.][0-9]+([.][0-9]+)?)?)"
+                _fftw_wtc_version ${_fftw_wtc_stdout})
+        string(REPLACE " " ";" _fftw_wtc_version_list ${_fftw_wtc_version})
+        list(GET _fftw_wtc_version_list -1 FFTW_VERSION)
+    else()
+        message(WARNING "Error running ${FFTW_ROOT}/bin/fftw-wisdom-to-conf. "
+                        "Could not determine FFTW version.
+Output:
+${_fftw_wtc_stdout}
+Error:
+${_fftw_wtc_stderr}")
+    endif()
 endif()
-
-# Set variables based on pkg-config results
-set(FFTW_VERSION ${PKG_FFTW_VERSION})
 
 #Check whether to search static or dynamic libs
 set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This module sets the following variables:
 - `FFTW_LIBRARIES`              ... full paths to all found fftw libraries
 - `FFTW_[component]_LIB`        ... full path to one of the components (see below)
 - `FFTW_INCLUDE_DIRS`           ... fftw include directory paths
+- `FFTW_VERSION`                ... version of the found fftw library
 
 The following variables will be checked by the module:
 - `FFTW_USE_STATIC_LIBS`        ... if true, only static libraries are found, otherwise both static and shared.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CMake module for finding FFTW 3 using find_package
 Once added to your project, this module allows you to find FFTW libraries and headers using the CMake `find_package` command:
 
 ```cmake
-find_package(FFTW [REQUIRED] [QUIET] [COMPONENTS component1 ... componentX] )
+find_package(FFTW [<version>] [REQUIRED] [QUIET] [COMPONENTS component1 ... componentX] )
 ```
 
 This module sets the following variables:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,28 +4,8 @@ project(test_findFFTW NONE)
 # Add the parent directory (repo root) to the module path so CMake can find FindFFTW.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
-# ---------------------------------------------------------------------------
-# Build find_package arguments
-# ---------------------------------------------------------------------------
-
-# Resolve version argument from FFTW_TEST_VERSION
-set(_fftw_find_version "")
-if(DEFINED FFTW_TEST_VERSION)
-    set(_fftw_find_version "${FFTW_TEST_VERSION}")
-endif()
-
-# Collect COMPONENTS argument
-set(_fftw_components "")
-if(DEFINED FFTW_TEST_COMPONENTS)
-    set(_fftw_components COMPONENTS ${FFTW_TEST_COMPONENTS})
-endif()
-
 # Call find_package with the assembled arguments
-if(_fftw_find_version)
-    find_package(FFTW ${_fftw_find_version} REQUIRED ${_fftw_components})
-else()
-    find_package(FFTW REQUIRED ${_fftw_components})
-endif()
+find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED ${FFTW_TEST_COMPONENTS})
 
 # ---------------------------------------------------------------------------
 # Check that the basic variables are set
@@ -34,33 +14,25 @@ if(NOT FFTW_FOUND)
     message(FATAL_ERROR "FFTW_FOUND is not TRUE after find_package(FFTW REQUIRED)")
 endif()
 
-if("${FFTW_VERSION}" STREQUAL "")
-    message(FATAL_ERROR "FFTW_VERSION is empty after find_package(FFTW REQUIRED)")
-endif()
-
-if("${FFTW_INCLUDE_DIRS}" STREQUAL "")
+if(NOT FFTW_INCLUDE_DIRS)
     message(FATAL_ERROR "FFTW_INCLUDE_DIRS is empty after find_package(FFTW REQUIRED)")
 endif()
 
-if("${FFTW_LIBRARIES}" STREQUAL "")
+if(NOT FFTW_LIBRARIES)
     message(FATAL_ERROR "FFTW_LIBRARIES is empty after find_package(FFTW REQUIRED)")
+endif()
+
+if(NOT FFTW_VERSION)
+    message(FATAL_ERROR "FFTW_VERSION is empty after find_package(FFTW REQUIRED)")
 endif()
 
 # ---------------------------------------------------------------------------
 # Version checks
 # ---------------------------------------------------------------------------
-if(_fftw_find_version)
-    if("${FFTW_VERSION}" STREQUAL "")
+if(FFTW_TEST_VERSION)
+    if(NOT "${FFTW_VERSION}" VERSION_GREATER_EQUAL "${FFTW_TEST_VERSION}")
         message(FATAL_ERROR
-            "FFTW_VERSION is not set after find_package. "
-            "Version detection requires pkg-config, which is not used when "
-            "FFTW_ROOT is set or pkg-config is unavailable. "
-            "Do not set FFTW_TEST_VERSION when using FFTW_ROOT.")
-    endif()
-
-    if(NOT "${FFTW_VERSION}" VERSION_GREATER_EQUAL "${_fftw_find_version}")
-        message(FATAL_ERROR
-            "Expected FFTW_VERSION >= ${_fftw_find_version} but got ${FFTW_VERSION}")
+            "Expected FFTW_VERSION >= ${FFTW_TEST_VERSION} but got ${FFTW_VERSION}")
     endif()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,13 @@ project(test_findFFTW NONE)
 # Add the parent directory (repo root) to the module path so CMake can find FindFFTW.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
-# Call find_package with the assembled arguments
-find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED ${FFTW_TEST_COMPONENTS})
+# Find FFTW. If FFTW_TEST_COMPONENTS is given (semicolon-separated list), those
+# components are required; otherwise we just require that FFTW itself is found.
+if(FFTW_TEST_COMPONENTS)
+    find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED COMPONENTS ${FFTW_TEST_COMPONENTS})
+else()
+    find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED)
+endif()
 
 # ---------------------------------------------------------------------------
 # Check that the basic variables are set

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,12 +4,27 @@ project(test_findFFTW NONE)
 # Add the parent directory (repo root) to the module path so CMake can find FindFFTW.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
-# Find FFTW. If FFTW_TEST_COMPONENTS is given (semicolon-separated list), those
-# components are required; otherwise we just require that FFTW itself is found.
+# ---------------------------------------------------------------------------
+# Build find_package arguments
+# ---------------------------------------------------------------------------
+
+# Resolve version argument from FFTW_TEST_VERSION
+set(_fftw_find_version "")
+if(DEFINED FFTW_TEST_VERSION)
+    set(_fftw_find_version "${FFTW_TEST_VERSION}")
+endif()
+
+# Collect COMPONENTS argument
+set(_fftw_components "")
 if(DEFINED FFTW_TEST_COMPONENTS)
-    find_package(FFTW REQUIRED COMPONENTS ${FFTW_TEST_COMPONENTS})
+    set(_fftw_components COMPONENTS ${FFTW_TEST_COMPONENTS})
+endif()
+
+# Call find_package with the assembled arguments
+if(_fftw_find_version)
+    find_package(FFTW ${_fftw_find_version} REQUIRED ${_fftw_components})
 else()
-    find_package(FFTW REQUIRED)
+    find_package(FFTW REQUIRED ${_fftw_components})
 endif()
 
 # ---------------------------------------------------------------------------
@@ -19,12 +34,34 @@ if(NOT FFTW_FOUND)
     message(FATAL_ERROR "FFTW_FOUND is not TRUE after find_package(FFTW REQUIRED)")
 endif()
 
-if(NOT FFTW_INCLUDE_DIRS)
+if("${FFTW_VERSION}" STREQUAL "")
+    message(FATAL_ERROR "FFTW_VERSION is empty after find_package(FFTW REQUIRED)")
+endif()
+
+if("${FFTW_INCLUDE_DIRS}" STREQUAL "")
     message(FATAL_ERROR "FFTW_INCLUDE_DIRS is empty after find_package(FFTW REQUIRED)")
 endif()
 
-if(NOT FFTW_LIBRARIES)
+if("${FFTW_LIBRARIES}" STREQUAL "")
     message(FATAL_ERROR "FFTW_LIBRARIES is empty after find_package(FFTW REQUIRED)")
+endif()
+
+# ---------------------------------------------------------------------------
+# Version checks
+# ---------------------------------------------------------------------------
+if(_fftw_find_version)
+    if("${FFTW_VERSION}" STREQUAL "")
+        message(FATAL_ERROR
+            "FFTW_VERSION is not set after find_package. "
+            "Version detection requires pkg-config, which is not used when "
+            "FFTW_ROOT is set or pkg-config is unavailable. "
+            "Do not set FFTW_TEST_VERSION when using FFTW_ROOT.")
+    endif()
+
+    if(NOT "${FFTW_VERSION}" VERSION_GREATER_EQUAL "${_fftw_find_version}")
+        message(FATAL_ERROR
+            "Expected FFTW_VERSION >= ${_fftw_find_version} but got ${FFTW_VERSION}")
+    endif()
 endif()
 
 # ---------------------------------------------------------------------------
@@ -71,6 +108,7 @@ endforeach()
 # ---------------------------------------------------------------------------
 message(STATUS "FindFFTW test passed!")
 message(STATUS "  FFTW_FOUND:        ${FFTW_FOUND}")
+message(STATUS "  FFTW_VERSION:      ${FFTW_VERSION}")
 message(STATUS "  FFTW_INCLUDE_DIRS: ${FFTW_INCLUDE_DIRS}")
 message(STATUS "  FFTW_LIBRARIES:    ${FFTW_LIBRARIES}")
 


### PR DESCRIPTION
Current implementation does not support specifying minimum version for FFTW, e.g.
```cmake
find_package(FFTW 3.3.11 REQUIRED)
```
Current implementation will set FFTW_FOUND even if fftw found has a version less than specified.

Add VERSION_VAR points to PKG_FFTW_VERSION fix that.

Reference: https://cmake.org/cmake/help/v3.10/module/FindPackageHandleStandardArgs.html.
> 
> VERSION_VAR \<version-var\>
> Specify the name of a variable that holds the version of the package that has been found. This version will be checked against the (potentially) specified required version given to the [find_package()](https://cmake.org/cmake/help/v3.10/command/find_package.html#command:find_package) call, including its EXACT option. The default messages include information about the required version and the version which has been actually found, both if the version is ok or not.