### PR TITLE
Format cmake file with cmake-format default settings

### DIFF
--- a/FindFFTW.cmake
+++ b/FindFFTW.cmake
@@ -1,3 +1,4 @@
+# ~~~
 # - Find the FFTW library
 # https://github.com/egpbos/findFFTW/
 # Original version of this file:
@@ -33,411 +34,391 @@
 #   DOUBLE_OPENMP_LIB
 #   LONGDOUBLE_OPENMP_LIB
 #
+# ~~~
 
+# ~~~
 # TODO (maybe): extend with ExternalProject download + build option
 # TODO: put on conda-forge
+# ~~~
 
-
-if( NOT FFTW_ROOT AND DEFINED ENV{FFTWDIR} )
-    set( FFTW_ROOT $ENV{FFTWDIR} )
+if(NOT FFTW_ROOT AND DEFINED ENV{FFTWDIR})
+  set(FFTW_ROOT $ENV{FFTWDIR})
 endif()
 
 # Check if we can use PkgConfig
 find_package(PkgConfig)
 
 # Determine from PKG
-if( PKG_CONFIG_FOUND AND NOT FFTW_ROOT )
-    pkg_check_modules( PKG_FFTW QUIET "fftw3" )
-    set( FFTW_VERSION ${PKG_FFTW_VERSION} )
+if(PKG_CONFIG_FOUND AND NOT FFTW_ROOT)
+  pkg_check_modules(PKG_FFTW QUIET "fftw3")
+  set(FFTW_VERSION ${PKG_FFTW_VERSION})
 else()
-    # If pkg-config was skipped, there seems no way to get the version directly.
-    # Try to deduce the version from fftw-wisdom-to-conf instead.
-    #   (From @kprussing. See https://github.com/egpbos/findFFTW/pull/8)
-    execute_process(COMMAND ${FFTW_ROOT}/bin/fftw-wisdom-to-conf -V
-                    RESULT_VARIABLE _fftw_wtc_success
-                    OUTPUT_VARIABLE _fftw_wtc_stdout
-                    ERROR_VARIABLE _fftw_wtc_stderr)
-    if (_fftw_wtc_success EQUAL 0)
-        string(REGEX MATCH "FFTW *version *([0-9]+([.][0-9]+([.][0-9]+)?)?)"
-                _fftw_wtc_version ${_fftw_wtc_stdout})
-        string(REPLACE " " ";" _fftw_wtc_version_list ${_fftw_wtc_version})
-        list(GET _fftw_wtc_version_list -1 FFTW_VERSION)
-    else()
-        message(WARNING "Error running ${FFTW_ROOT}/bin/fftw-wisdom-to-conf. "
-                        "Could not determine FFTW version.
+  # If pkg-config was skipped, there seems no way to get the version directly.
+  # Try to deduce the version from fftw-wisdom-to-conf instead. (From
+  # @kprussing. See https://github.com/egpbos/findFFTW/pull/8)
+  execute_process(
+    COMMAND ${FFTW_ROOT}/bin/fftw-wisdom-to-conf -V
+    RESULT_VARIABLE _fftw_wtc_success
+    OUTPUT_VARIABLE _fftw_wtc_stdout
+    ERROR_VARIABLE _fftw_wtc_stderr)
+  if(_fftw_wtc_success EQUAL 0)
+    string(REGEX MATCH "FFTW *version *([0-9]+([.][0-9]+([.][0-9]+)?)?)"
+                 _fftw_wtc_version ${_fftw_wtc_stdout})
+    string(REPLACE " " ";" _fftw_wtc_version_list ${_fftw_wtc_version})
+    list(GET _fftw_wtc_version_list -1 FFTW_VERSION)
+  else()
+    message(
+      WARNING
+        "Error running ${FFTW_ROOT}/bin/fftw-wisdom-to-conf. "
+        "Could not determine FFTW version.
 Output:
 ${_fftw_wtc_stdout}
 Error:
 ${_fftw_wtc_stderr}")
-    endif()
+  endif()
 endif()
 
-#Check whether to search static or dynamic libs
-set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+# Check whether to search static or dynamic libs
+set(CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
-if( ${FFTW_USE_STATIC_LIBS} )
-    set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
+if(${FFTW_USE_STATIC_LIBS})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
 else()
-    set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV})
 endif()
 
-if( FFTW_ROOT )
-    # find libs
+if(FFTW_ROOT)
+  # find libs
 
-    find_library(
-        FFTW_DOUBLE_LIB
-        NAMES "fftw3" libfftw3-3
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_DOUBLE_LIB
+    NAMES "fftw3" libfftw3-3
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_DOUBLE_THREADS_LIB
-        NAMES "fftw3_threads"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_DOUBLE_THREADS_LIB
+    NAMES "fftw3_threads"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_DOUBLE_OPENMP_LIB
-        NAMES "fftw3_omp"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_DOUBLE_OPENMP_LIB
+    NAMES "fftw3_omp"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_DOUBLE_MPI_LIB
-        NAMES "fftw3_mpi"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_DOUBLE_MPI_LIB
+    NAMES "fftw3_mpi"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_FLOAT_LIB
-        NAMES "fftw3f" libfftw3f-3
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_FLOAT_LIB
+    NAMES "fftw3f" libfftw3f-3
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_FLOAT_THREADS_LIB
-        NAMES "fftw3f_threads"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_FLOAT_THREADS_LIB
+    NAMES "fftw3f_threads"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_FLOAT_OPENMP_LIB
-        NAMES "fftw3f_omp"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_FLOAT_OPENMP_LIB
+    NAMES "fftw3f_omp"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_FLOAT_MPI_LIB
-        NAMES "fftw3f_mpi"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_FLOAT_MPI_LIB
+    NAMES "fftw3f_mpi"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_LONGDOUBLE_LIB
-        NAMES "fftw3l" libfftw3l-3
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_LONGDOUBLE_LIB
+    NAMES "fftw3l" libfftw3l-3
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_LONGDOUBLE_THREADS_LIB
-        NAMES "fftw3l_threads"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_LONGDOUBLE_THREADS_LIB
+    NAMES "fftw3l_threads"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_LONGDOUBLE_OPENMP_LIB
-        NAMES "fftw3l_omp"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_LONGDOUBLE_OPENMP_LIB
+    NAMES "fftw3l_omp"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    find_library(
-        FFTW_LONGDOUBLE_MPI_LIB
-        NAMES "fftw3l_mpi"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "lib" "lib64"
-        NO_DEFAULT_PATH
-        )
+  find_library(
+    FFTW_LONGDOUBLE_MPI_LIB
+    NAMES "fftw3l_mpi"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH)
 
-    #find includes
-    find_path(FFTW_INCLUDE_DIRS
-        NAMES "fftw3.h"
-        PATHS ${FFTW_ROOT}
-        PATH_SUFFIXES "include"
-        NO_DEFAULT_PATH
-        )
+  # find includes
+  find_path(
+    FFTW_INCLUDE_DIRS
+    NAMES "fftw3.h"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "include"
+    NO_DEFAULT_PATH)
 
 else()
 
-    find_library(
-        FFTW_DOUBLE_LIB
-        NAMES "fftw3" libfftw3-3
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_DOUBLE_LIB
+    NAMES "fftw3" libfftw3-3
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_DOUBLE_THREADS_LIB
-        NAMES "fftw3_threads"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_DOUBLE_THREADS_LIB
+    NAMES "fftw3_threads"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_DOUBLE_OPENMP_LIB
-        NAMES "fftw3_omp"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_DOUBLE_OPENMP_LIB
+    NAMES "fftw3_omp"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_DOUBLE_MPI_LIB
-        NAMES "fftw3_mpi"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_DOUBLE_MPI_LIB
+    NAMES "fftw3_mpi"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_FLOAT_LIB
-        NAMES "fftw3f" libfftw3f-3
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_FLOAT_LIB
+    NAMES "fftw3f" libfftw3f-3
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_FLOAT_THREADS_LIB
-        NAMES "fftw3f_threads"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_FLOAT_THREADS_LIB
+    NAMES "fftw3f_threads"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_FLOAT_OPENMP_LIB
-        NAMES "fftw3f_omp"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_FLOAT_OPENMP_LIB
+    NAMES "fftw3f_omp"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_FLOAT_MPI_LIB
-        NAMES "fftw3f_mpi"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_FLOAT_MPI_LIB
+    NAMES "fftw3f_mpi"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_LONGDOUBLE_LIB
-        NAMES "fftw3l" libfftw3l-3
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_LONGDOUBLE_LIB
+    NAMES "fftw3l" libfftw3l-3
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(
-        FFTW_LONGDOUBLE_THREADS_LIB
-        NAMES "fftw3l_threads"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_LONGDOUBLE_THREADS_LIB
+    NAMES "fftw3l_threads"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(FFTW_LONGDOUBLE_OPENMP_LIB
-        NAMES "fftw3l_omp"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_LONGDOUBLE_OPENMP_LIB
+    NAMES "fftw3l_omp"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_library(FFTW_LONGDOUBLE_MPI_LIB
-        NAMES "fftw3l_mpi"
-        PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-        )
+  find_library(
+    FFTW_LONGDOUBLE_MPI_LIB
+    NAMES "fftw3l_mpi"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR})
 
-    find_path(FFTW_INCLUDE_DIRS
-        NAMES "fftw3.h"
-        PATHS ${PKG_FFTW_INCLUDE_DIRS} ${INCLUDE_INSTALL_DIR}
-        )
+  find_path(
+    FFTW_INCLUDE_DIRS
+    NAMES "fftw3.h"
+    PATHS ${PKG_FFTW_INCLUDE_DIRS} ${INCLUDE_INSTALL_DIR})
 
-endif( FFTW_ROOT )
+endif(FFTW_ROOT)
 
-#--------------------------------------- components
+# --------------------------------------- components
 
-if (FFTW_DOUBLE_LIB)
-    set(FFTW_DOUBLE_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_LIB})
-    add_library(FFTW::Double INTERFACE IMPORTED)
-    set_target_properties(FFTW::Double
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_LIB}"
-        )
+if(FFTW_DOUBLE_LIB)
+  set(FFTW_DOUBLE_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_LIB})
+  add_library(FFTW::Double INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::Double PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                            INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_LIB}")
 else()
-    set(FFTW_DOUBLE_LIB_FOUND FALSE)
+  set(FFTW_DOUBLE_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_FLOAT_LIB)
-    set(FFTW_FLOAT_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_LIB})
-    add_library(FFTW::Float INTERFACE IMPORTED)
-    set_target_properties(FFTW::Float
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_LIB}"
-        )
+if(FFTW_FLOAT_LIB)
+  set(FFTW_FLOAT_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_LIB})
+  add_library(FFTW::Float INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::Float PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                           INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_LIB}")
 else()
-    set(FFTW_FLOAT_LIB_FOUND FALSE)
+  set(FFTW_FLOAT_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_LONGDOUBLE_LIB)
-    set(FFTW_LONGDOUBLE_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_LIB})
-    add_library(FFTW::LongDouble INTERFACE IMPORTED)
-    set_target_properties(FFTW::LongDouble
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_LIB}"
-        )
+if(FFTW_LONGDOUBLE_LIB)
+  set(FFTW_LONGDOUBLE_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_LIB})
+  add_library(FFTW::LongDouble INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::LongDouble
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_LIB}")
 else()
-    set(FFTW_LONGDOUBLE_LIB_FOUND FALSE)
+  set(FFTW_LONGDOUBLE_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_DOUBLE_THREADS_LIB)
-    set(FFTW_DOUBLE_THREADS_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_THREADS_LIB})
-    add_library(FFTW::DoubleThreads INTERFACE IMPORTED)
-    set_target_properties(FFTW::DoubleThreads
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_THREADS_LIB}"
-        )
+if(FFTW_DOUBLE_THREADS_LIB)
+  set(FFTW_DOUBLE_THREADS_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_THREADS_LIB})
+  add_library(FFTW::DoubleThreads INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::DoubleThreads
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_THREADS_LIB}")
 else()
-    set(FFTW_DOUBLE_THREADS_LIB_FOUND FALSE)
+  set(FFTW_DOUBLE_THREADS_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_FLOAT_THREADS_LIB)
-    set(FFTW_FLOAT_THREADS_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_THREADS_LIB})
-    add_library(FFTW::FloatThreads INTERFACE IMPORTED)
-    set_target_properties(FFTW::FloatThreads
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_THREADS_LIB}"
-        )
+if(FFTW_FLOAT_THREADS_LIB)
+  set(FFTW_FLOAT_THREADS_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_THREADS_LIB})
+  add_library(FFTW::FloatThreads INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::FloatThreads
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_THREADS_LIB}")
 else()
-    set(FFTW_FLOAT_THREADS_LIB_FOUND FALSE)
+  set(FFTW_FLOAT_THREADS_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_LONGDOUBLE_THREADS_LIB)
-    set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_THREADS_LIB})
-    add_library(FFTW::LongDoubleThreads INTERFACE IMPORTED)
-    set_target_properties(FFTW::LongDoubleThreads
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_THREADS_LIB}"
-        )
+if(FFTW_LONGDOUBLE_THREADS_LIB)
+  set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_THREADS_LIB})
+  add_library(FFTW::LongDoubleThreads INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::LongDoubleThreads
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_THREADS_LIB}")
 else()
-    set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND FALSE)
+  set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_DOUBLE_OPENMP_LIB)
-    set(FFTW_DOUBLE_OPENMP_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_OPENMP_LIB})
-    add_library(FFTW::DoubleOpenMP INTERFACE IMPORTED)
-    set_target_properties(FFTW::DoubleOpenMP
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_OPENMP_LIB}"
-        )
+if(FFTW_DOUBLE_OPENMP_LIB)
+  set(FFTW_DOUBLE_OPENMP_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_OPENMP_LIB})
+  add_library(FFTW::DoubleOpenMP INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::DoubleOpenMP
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_OPENMP_LIB}")
 else()
-    set(FFTW_DOUBLE_OPENMP_LIB_FOUND FALSE)
+  set(FFTW_DOUBLE_OPENMP_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_FLOAT_OPENMP_LIB)
-    set(FFTW_FLOAT_OPENMP_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_OPENMP_LIB})
-    add_library(FFTW::FloatOpenMP INTERFACE IMPORTED)
-    set_target_properties(FFTW::FloatOpenMP
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_OPENMP_LIB}"
-        )
+if(FFTW_FLOAT_OPENMP_LIB)
+  set(FFTW_FLOAT_OPENMP_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_OPENMP_LIB})
+  add_library(FFTW::FloatOpenMP INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::FloatOpenMP
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_OPENMP_LIB}")
 else()
-    set(FFTW_FLOAT_OPENMP_LIB_FOUND FALSE)
+  set(FFTW_FLOAT_OPENMP_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_LONGDOUBLE_OPENMP_LIB)
-    set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_OPENMP_LIB})
-    add_library(FFTW::LongDoubleOpenMP INTERFACE IMPORTED)
-    set_target_properties(FFTW::LongDoubleOpenMP
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_OPENMP_LIB}"
-        )
+if(FFTW_LONGDOUBLE_OPENMP_LIB)
+  set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_OPENMP_LIB})
+  add_library(FFTW::LongDoubleOpenMP INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::LongDoubleOpenMP
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_OPENMP_LIB}")
 else()
-    set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND FALSE)
+  set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_DOUBLE_MPI_LIB)
-    set(FFTW_DOUBLE_MPI_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_MPI_LIB})
-    add_library(FFTW::DoubleMPI INTERFACE IMPORTED)
-    set_target_properties(FFTW::DoubleMPI
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_MPI_LIB}"
-        )
+if(FFTW_DOUBLE_MPI_LIB)
+  set(FFTW_DOUBLE_MPI_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_MPI_LIB})
+  add_library(FFTW::DoubleMPI INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::DoubleMPI
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_MPI_LIB}")
 else()
-    set(FFTW_DOUBLE_MPI_LIB_FOUND FALSE)
+  set(FFTW_DOUBLE_MPI_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_FLOAT_MPI_LIB)
-    set(FFTW_FLOAT_MPI_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_MPI_LIB})
-    add_library(FFTW::FloatMPI INTERFACE IMPORTED)
-    set_target_properties(FFTW::FloatMPI
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_MPI_LIB}"
-        )
+if(FFTW_FLOAT_MPI_LIB)
+  set(FFTW_FLOAT_MPI_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_MPI_LIB})
+  add_library(FFTW::FloatMPI INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::FloatMPI
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_MPI_LIB}")
 else()
-    set(FFTW_FLOAT_MPI_LIB_FOUND FALSE)
+  set(FFTW_FLOAT_MPI_LIB_FOUND FALSE)
 endif()
 
-if (FFTW_LONGDOUBLE_MPI_LIB)
-    set(FFTW_LONGDOUBLE_MPI_LIB_FOUND TRUE)
-    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_MPI_LIB})
-    add_library(FFTW::LongDoubleMPI INTERFACE IMPORTED)
-    set_target_properties(FFTW::LongDoubleMPI
-        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_MPI_LIB}"
-        )
+if(FFTW_LONGDOUBLE_MPI_LIB)
+  set(FFTW_LONGDOUBLE_MPI_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_MPI_LIB})
+  add_library(FFTW::LongDoubleMPI INTERFACE IMPORTED)
+  set_target_properties(
+    FFTW::LongDoubleMPI
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_MPI_LIB}")
 else()
-    set(FFTW_LONGDOUBLE_MPI_LIB_FOUND FALSE)
+  set(FFTW_LONGDOUBLE_MPI_LIB_FOUND FALSE)
 endif()
 
-#--------------------------------------- end components
+# --------------------------------------- end components
 
-set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV})
 
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(FFTW
-    REQUIRED_VARS FFTW_INCLUDE_DIRS
-    VERSION_VAR FFTW_VERSION
-    HANDLE_COMPONENTS
-    )
+find_package_handle_standard_args(
+  FFTW
+  REQUIRED_VARS FFTW_INCLUDE_DIRS
+  VERSION_VAR FFTW_VERSION
+  HANDLE_COMPONENTS)
 
 mark_as_advanced(
-    FFTW_INCLUDE_DIRS
-    FFTW_LIBRARIES
-    FFTW_FLOAT_LIB
-    FFTW_DOUBLE_LIB
-    FFTW_LONGDOUBLE_LIB
-    FFTW_FLOAT_THREADS_LIB
-    FFTW_DOUBLE_THREADS_LIB
-    FFTW_LONGDOUBLE_THREADS_LIB
-    FFTW_FLOAT_OPENMP_LIB
-    FFTW_DOUBLE_OPENMP_LIB
-    FFTW_LONGDOUBLE_OPENMP_LIB
-    FFTW_FLOAT_MPI_LIB
-    FFTW_DOUBLE_MPI_LIB
-    FFTW_LONGDOUBLE_MPI_LIB
-    )
+  FFTW_INCLUDE_DIRS
+  FFTW_LIBRARIES
+  FFTW_FLOAT_LIB
+  FFTW_DOUBLE_LIB
+  FFTW_LONGDOUBLE_LIB
+  FFTW_FLOAT_THREADS_LIB
+  FFTW_DOUBLE_THREADS_LIB
+  FFTW_LONGDOUBLE_THREADS_LIB
+  FFTW_FLOAT_OPENMP_LIB
+  FFTW_DOUBLE_OPENMP_LIB
+  FFTW_LONGDOUBLE_OPENMP_LIB
+  FFTW_FLOAT_MPI_LIB
+  FFTW_DOUBLE_MPI_LIB
+  FFTW_LONGDOUBLE_MPI_LIB)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,83 +1,90 @@
 cmake_minimum_required(VERSION 3.10)
 project(test_findFFTW NONE)
 
-# Add the parent directory (repo root) to the module path so CMake can find FindFFTW.cmake
+# Add the parent directory (repo root) to the module path so CMake can find
+# FindFFTW.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 # Find FFTW. If FFTW_TEST_COMPONENTS is given (semicolon-separated list), those
 # components are required; otherwise we just require that FFTW itself is found.
 if(FFTW_TEST_COMPONENTS)
-    find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED COMPONENTS ${FFTW_TEST_COMPONENTS})
+  find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED
+               COMPONENTS ${FFTW_TEST_COMPONENTS})
 else()
-    find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED)
+  find_package(FFTW ${FFTW_TEST_VERSION} REQUIRED)
 endif()
 
 # ---------------------------------------------------------------------------
 # Check that the basic variables are set
 # ---------------------------------------------------------------------------
 if(NOT FFTW_FOUND)
-    message(FATAL_ERROR "FFTW_FOUND is not TRUE after find_package(FFTW REQUIRED)")
+  message(
+    FATAL_ERROR "FFTW_FOUND is not TRUE after find_package(FFTW REQUIRED)")
 endif()
 
 if(NOT FFTW_INCLUDE_DIRS)
-    message(FATAL_ERROR "FFTW_INCLUDE_DIRS is empty after find_package(FFTW REQUIRED)")
+  message(
+    FATAL_ERROR "FFTW_INCLUDE_DIRS is empty after find_package(FFTW REQUIRED)")
 endif()
 
 if(NOT FFTW_LIBRARIES)
-    message(FATAL_ERROR "FFTW_LIBRARIES is empty after find_package(FFTW REQUIRED)")
+  message(
+    FATAL_ERROR "FFTW_LIBRARIES is empty after find_package(FFTW REQUIRED)")
 endif()
 
 if(NOT FFTW_VERSION)
-    message(FATAL_ERROR "FFTW_VERSION is empty after find_package(FFTW REQUIRED)")
+  message(FATAL_ERROR "FFTW_VERSION is empty after find_package(FFTW REQUIRED)")
 endif()
 
 # ---------------------------------------------------------------------------
 # Version checks
 # ---------------------------------------------------------------------------
 if(FFTW_TEST_VERSION)
-    if(NOT "${FFTW_VERSION}" VERSION_GREATER_EQUAL "${FFTW_TEST_VERSION}")
-        message(FATAL_ERROR
-            "Expected FFTW_VERSION >= ${FFTW_TEST_VERSION} but got ${FFTW_VERSION}")
-    endif()
+  if(NOT "${FFTW_VERSION}" VERSION_GREATER_EQUAL "${FFTW_TEST_VERSION}")
+    message(
+      FATAL_ERROR
+        "Expected FFTW_VERSION >= ${FFTW_TEST_VERSION} but got ${FFTW_VERSION}")
+  endif()
 endif()
 
 # ---------------------------------------------------------------------------
 # Map component names to their CMake imported target names
 # ---------------------------------------------------------------------------
-set(FFTW_DOUBLE_LIB_TARGET          FFTW::Double)
-set(FFTW_FLOAT_LIB_TARGET           FFTW::Float)
-set(FFTW_LONGDOUBLE_LIB_TARGET      FFTW::LongDouble)
-set(FFTW_DOUBLE_THREADS_LIB_TARGET  FFTW::DoubleThreads)
-set(FFTW_FLOAT_THREADS_LIB_TARGET   FFTW::FloatThreads)
+set(FFTW_DOUBLE_LIB_TARGET FFTW::Double)
+set(FFTW_FLOAT_LIB_TARGET FFTW::Float)
+set(FFTW_LONGDOUBLE_LIB_TARGET FFTW::LongDouble)
+set(FFTW_DOUBLE_THREADS_LIB_TARGET FFTW::DoubleThreads)
+set(FFTW_FLOAT_THREADS_LIB_TARGET FFTW::FloatThreads)
 set(FFTW_LONGDOUBLE_THREADS_LIB_TARGET FFTW::LongDoubleThreads)
-set(FFTW_DOUBLE_OPENMP_LIB_TARGET   FFTW::DoubleOpenMP)
-set(FFTW_FLOAT_OPENMP_LIB_TARGET    FFTW::FloatOpenMP)
+set(FFTW_DOUBLE_OPENMP_LIB_TARGET FFTW::DoubleOpenMP)
+set(FFTW_FLOAT_OPENMP_LIB_TARGET FFTW::FloatOpenMP)
 set(FFTW_LONGDOUBLE_OPENMP_LIB_TARGET FFTW::LongDoubleOpenMP)
-set(FFTW_DOUBLE_MPI_LIB_TARGET      FFTW::DoubleMPI)
-set(FFTW_FLOAT_MPI_LIB_TARGET       FFTW::FloatMPI)
-set(FFTW_LONGDOUBLE_MPI_LIB_TARGET  FFTW::LongDoubleMPI)
+set(FFTW_DOUBLE_MPI_LIB_TARGET FFTW::DoubleMPI)
+set(FFTW_FLOAT_MPI_LIB_TARGET FFTW::FloatMPI)
+set(FFTW_LONGDOUBLE_MPI_LIB_TARGET FFTW::LongDoubleMPI)
 
 # ---------------------------------------------------------------------------
 # Check per-component variables and targets for each expected component
 # ---------------------------------------------------------------------------
 foreach(component IN LISTS FFTW_TEST_COMPONENTS)
-    if(NOT FFTW_${component}_FOUND)
-        message(FATAL_ERROR
-            "Expected FFTW component ${component} was not found: "
-            "FFTW_${component}_FOUND is not TRUE")
-    endif()
+  if(NOT FFTW_${component}_FOUND)
+    message(FATAL_ERROR "Expected FFTW component ${component} was not found: "
+                        "FFTW_${component}_FOUND is not TRUE")
+  endif()
 
-    # The library variable name is FFTW_<component>, e.g. FFTW_DOUBLE_LIB
-    if(NOT FFTW_${component})
-        message(FATAL_ERROR
-            "FFTW_${component} is empty for found component ${component}")
-    endif()
+  # The library variable name is FFTW_<component>, e.g. FFTW_DOUBLE_LIB
+  if(NOT FFTW_${component})
+    message(
+      FATAL_ERROR "FFTW_${component} is empty for found component ${component}")
+  endif()
 
-    set(_target "${FFTW_${component}_TARGET}")
-    if(_target AND NOT TARGET ${_target})
-        message(FATAL_ERROR
-            "CMake imported target ${_target} was not created for component ${component}")
-    endif()
+  set(_target "${FFTW_${component}_TARGET}")
+  if(_target AND NOT TARGET ${_target})
+    message(
+      FATAL_ERROR
+        "CMake imported target ${_target} was not created for component ${component}"
+    )
+  endif()
 endforeach()
 
 # ---------------------------------------------------------------------------
@@ -90,12 +97,21 @@ message(STATUS "  FFTW_INCLUDE_DIRS: ${FFTW_INCLUDE_DIRS}")
 message(STATUS "  FFTW_LIBRARIES:    ${FFTW_LIBRARIES}")
 
 set(_all_components
-    DOUBLE_LIB FLOAT_LIB LONGDOUBLE_LIB
-    DOUBLE_THREADS_LIB FLOAT_THREADS_LIB LONGDOUBLE_THREADS_LIB
-    DOUBLE_OPENMP_LIB  FLOAT_OPENMP_LIB  LONGDOUBLE_OPENMP_LIB
-    DOUBLE_MPI_LIB     FLOAT_MPI_LIB     LONGDOUBLE_MPI_LIB
-)
+    DOUBLE_LIB
+    FLOAT_LIB
+    LONGDOUBLE_LIB
+    DOUBLE_THREADS_LIB
+    FLOAT_THREADS_LIB
+    LONGDOUBLE_THREADS_LIB
+    DOUBLE_OPENMP_LIB
+    FLOAT_OPENMP_LIB
+    LONGDOUBLE_OPENMP_LIB
+    DOUBLE_MPI_LIB
+    FLOAT_MPI_LIB
+    LONGDOUBLE_MPI_LIB)
 message(STATUS "  Component status:")
 foreach(_comp IN LISTS _all_components)
-    message(STATUS "    FFTW_${_comp}_FOUND=${FFTW_${_comp}_FOUND}  lib=${FFTW_${_comp}}")
+  message(
+    STATUS
+      "    FFTW_${_comp}_FOUND=${FFTW_${_comp}_FOUND}  lib=${FFTW_${_comp}}")
 endforeach()


### PR DESCRIPTION
Simply format code with default cmake-format (also added some necessary `~~~` fence to annotations).

The default config uses 2-space indent and 80-char max width so they look quite different as before.

Follow up https://github.com/egpbos/findFFTW/pull/10#issuecomment-4751364187 .